### PR TITLE
Improve prompt for silence settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,8 @@ GUILD_ID=<YOUR-GUILD-ID>
 USER_ID=<YOUR-USER-ID>
 VOICE_CHANNEL_ID=<VOICE_CHANNEL_ID>
 MUSIC_BOT_URL="<YOUR-MUSIC-BOT-URL>"
+# Optional: disable HTTP connection pooling if it causes issues
+USE_HTTP_SESSION=1
+# Optional: tune speech detection sensitivity
+VOSK_RMS_THRESHOLD=900
+VOSK_SILENCE_DURATION_SECONDS=1.2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ GUILD_ID="<DISCORD-GUILD-ID>"
 USER_ID="<YOUR-DISCORD-USER-ID>"
 VOICE_CHANNEL_ID="<TARGET-VOICE-CHANNEL-ID>"
 MUSIC_BOT_URL="<YOUR-MUSIC-BOT-URL>"
+USE_HTTP_SESSION=1
+VOSK_RMS_THRESHOLD=900
+VOSK_SILENCE_DURATION_SECONDS=1.2
 ```
+The last three variables are optional. `USE_HTTP_SESSION` controls whether HTTP
+connections are pooled. Set it to `0` if the music bot has trouble with
+persistent connections. `VOSK_RMS_THRESHOLD` and
+`VOSK_SILENCE_DURATION_SECONDS` adjust the silence detection sensitivity.
+Jarvis shows these values at startup and lets you adjust them interactively.
 
 ## Setup
 1. Install the required Python packages:

--- a/agents.md
+++ b/agents.md
@@ -40,6 +40,7 @@ This document outlines the fundamental principles guiding the development of the
     *   Continuously profile and monitor performance to identify and address bottlenecks.
     *   Design UI feedback (console or otherwise) to be immediate, even if the full processing takes a moment (e.g., partial transcription updates).
     *   Silence detection parameters should be tunable to balance responsiveness with capturing the user's full intent.
+    *   Reuse HTTP connections when possible to minimize request latency, but allow disabling pooling if compatibility issues arise.
 
 ## 4. Modularity and Clarity
 

--- a/jarvis.py
+++ b/jarvis.py
@@ -59,7 +59,9 @@ class AsyncTTS:
 tts = AsyncTTS()                              # Async text-to-speech engine
 
 # HTTP session for reusing connections (improves performance by pooling connections)
-session = requests.Session()
+# Set USE_HTTP_SESSION=0 in your .env to disable pooling if it causes issues.
+USE_HTTP_SESSION = os.getenv("USE_HTTP_SESSION", "1") != "0"
+session = requests.Session() if USE_HTTP_SESSION else requests
 
 # Music bot configuration from environment
 guild_id = os.getenv("GUILD_ID")             # Discord server ID
@@ -244,10 +246,15 @@ def listen_for_voice_commands():
 def prompt_for_silence_settings():
     """Prompts the user to adjust silence detection settings at startup."""
     console_ui.print_header("Silence Detection Settings (Optional)")
+    console_ui.print_info(
+        "Values are loaded from the VOSK_RMS_THRESHOLD and VOSK_SILENCE_DURATION_SECONDS variables in .env."
+    )
 
     # RMS Threshold
     current_rms = get_rms_threshold()
-    console_ui.print_info(f"Current RMS Threshold: {current_rms} (Default: 900)")
+    console_ui.print_info(
+        f"Current RMS Threshold: {current_rms} (Default: 900)"
+    )
     console_ui.print_info("Lower values are more sensitive to silence; higher values are less sensitive.")
     new_rms_str = console_ui.console.input(f"[prompt_style]Enter new RMS Threshold (e.g., 500-1500) or press Enter to keep [{current_rms}]: [/prompt_style]").strip()
     if new_rms_str:
@@ -259,7 +266,9 @@ def prompt_for_silence_settings():
 
     # Silence Duration
     current_duration = get_silence_duration_seconds()
-    console_ui.print_info(f"\nCurrent Silence Duration: {current_duration:.1f}s (Default: 1.2s)")
+    console_ui.print_info(
+        f"\nCurrent Silence Duration: {current_duration:.1f}s (Default: 1.2s)"
+    )
     console_ui.print_info("Longer duration allows for more pauses; shorter duration is more responsive.")
     new_duration_str = console_ui.console.input(f"[prompt_style]Enter new Silence Duration in seconds (e.g., 0.8-2.5) or press Enter to keep [{current_duration:.1f}s]: [/prompt_style]").strip()
     if new_duration_str:

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,9 +1,13 @@
 """
 Real-time speech transcription module using Vosk.
 
-This module provides continuous speech-to-text functionality with silence detection
-for automatic termination. It uses the Vosk offline speech recognition engine
-with a pre-loaded model for efficient, low-latency transcription.
+This module provides continuous speech-to-text functionality with silence
+detection for automatic termination. It uses the Vosk offline speech recognition
+engine with a pre-loaded model for efficient, low-latency transcription.
+
+Silence detection sensitivity is configurable. Initial values come from the
+optional environment variables `VOSK_RMS_THRESHOLD` and
+`VOSK_SILENCE_DURATION_SECONDS`, and Jarvis lets you adjust them at startup.
 """
 
 import json


### PR DESCRIPTION
## Summary
- document interactive tuning in README
- clarify how silence detection settings load and display current values
- tweak `prompt_for_silence_settings` startup messages
- restore default references in startup prompt

## Testing
- `python -m py_compile console_ui.py jarvis.py transcribe.py wake_word.py`


------
https://chatgpt.com/codex/tasks/task_e_6843dc16a784832c8ed0dd2e8b7646c8