### PR TITLE
Enable microphone info and optional TTS

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -57,3 +57,11 @@ This document outlines the fundamental principles guiding the development of the
 ---
 
 These principles should serve as a guide for all development decisions. While trade-offs are sometimes necessary, deviations should be consciously evaluated against these core tenets.
+
+## 5. Preserve Helpful Comments
+
+*   **Objective**: Keep existing explanatory comments intact unless they become incorrect or misleading.
+*   **Rationale**: Comments provide valuable context for future maintainers and help explain design choices.
+*   **Implementation**:
+    *   When modifying code, update related comments instead of deleting them.
+    *   Only remove a comment if it is clearly obsolete or redundant.


### PR DESCRIPTION
## Summary
- report which microphone is being used at startup
- allow disabling text to speech via a simple prompt
- gate TTS usage through global flag
- restore helpful comments and document that comments shouldn't be removed

## Testing
- `python -m py_compile console_ui.py jarvis.py transcribe.py wake_word.py`


------
https://chatgpt.com/codex/tasks/task_e_6843edf3fde4832c9c2c4a00423abeda